### PR TITLE
[25기 전태양] Nav 페이지 신규 장소 , 가성비 장소 쿼리 추가 연결

### DIFF
--- a/src/components/Nav/NavMain/LogInInfo/LogInInfo.js
+++ b/src/components/Nav/NavMain/LogInInfo/LogInInfo.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 class LogInInfo extends React.Component {
   render() {
-    const { kakaoList, kakaoLogOut } = this.props;
+    const { kakaoList, kakaoLogOut, handleInfoBytton } = this.props;
 
     return (
       <LogInInfoBox>
@@ -12,7 +12,7 @@ class LogInInfo extends React.Component {
         <BorderLine />
         <InfoContent>프로필</InfoContent>
         <InfoContent>메시지</InfoContent>
-        <Link to="/reservationDetails">
+        <Link to="/ReservationDetails/books?" onClick={handleInfoBytton}>
           <InfoContent>예약내역</InfoContent>
         </Link>
         <BorderLine />

--- a/src/components/Nav/NavMain/NavMain.js
+++ b/src/components/Nav/NavMain/NavMain.js
@@ -26,8 +26,12 @@ export default class NavMain extends Component {
             <NavItemHover onClick={handleCategotyButton}>
               모든 카테고리
             </NavItemHover>
-            <NavItem>둘러보기</NavItem>
-            <NavItem>인기장소</NavItem>
+            <Link to="/places?order=-created_at">
+              <NavItem>신규 장소</NavItem>
+            </Link>
+            <Link to="/places?order=price">
+              <NavItem>가성비 장소</NavItem>
+            </Link>
             <NavItem>WATCH</NavItem>
             <NavItem>매거진</NavItem>
             <i className="fas fa-search" onClick={handleSerchButton} />
@@ -54,7 +58,11 @@ export default class NavMain extends Component {
             )}
           </CategoryBox>
           {isInfoBytton && (
-            <LogInInfo kakaoList={kakaoList} kakaoLogOut={kakaoLogOut} />
+            <LogInInfo
+              kakaoList={kakaoList}
+              kakaoLogOut={kakaoLogOut}
+              handleInfoBytton={handleInfoBytton}
+            />
           )}
         </NavContent>
       </Nav>
@@ -140,6 +148,11 @@ const CategoryBox = styled.div`
     font-size: 20px;
     font-weight: 300;
     cursor: pointer;
+  }
+
+  a {
+    text-decoration: none;
+    color: black;
   }
 `;
 

--- a/src/components/Nav/SearchModal/SearchModal.js
+++ b/src/components/Nav/SearchModal/SearchModal.js
@@ -160,8 +160,10 @@ const LiveSearchBox = styled.div`
   flex-direction: column;
   max-width: 964px;
   width: 100%;
+  max-height: 400px;
   padding: 0.7em 3em;
   background-color: white;
+  overflow: scroll;
 
   a {
     text-decoration: none;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- Nav 페이지 신규 장소 , 가성비 장소 쿼리 추가 연결

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- Nav 메뉴 상단에 신규 장소 및 가성비 장소 카테고리 추가
- 쿼리 주소 `Link`태그로 연결 완료
<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 기능적으로 오류가 있던 부분을 동료분들이 발견해서 수정을 하게 되었는데 다음에는 한번더 꼼곰히 확인하고 머지를 시켜야 겠다고 생각했습니다. 

<br />

## :: 기타 질문 및 특이 사항

